### PR TITLE
[4.0] Fix tooltip for disabled grid button

### DIFF
--- a/libraries/cms/html/jgrid.php
+++ b/libraries/cms/html/jgrid.php
@@ -88,20 +88,21 @@ abstract class JHtmlJGrid
 		}
 		else
 		{
-			$html[] = '<a class="tbody-icon disabled jgrid' . ($tip ? ' hasTooltip' : '') . '"';
-			$html[] = $tip ? ' title="' . $title . '"' : '';
+			$html[] = '<a class="tbody-icon disabled jgrid"';
+			$html[] = $tip ? ' aria-labelledby="' . $ariaid . '"' : '';
 			$html[] = '>';
 
 			if ($active_class === 'protected')
 			{
-				$html[] = '<span class="icon-lock"></span>';
+				$html[] = '<span class="icon-lock" aria-hidden="true"></span>';
 			}
 			else
 			{
-				$html[] = '<span class="icon-' . $inactive_class . '"></span>';
+				$html[] = '<span class="icon-' . $inactive_class . '" aria-hidden="true"></span>';
 			}
 
 			$html[] = '</a>';
+			$html[] = $tip ? '<div role="tooltip" id="' . $ariaid . '">' . $title . '</div>' : '';
 		}
 
 		return implode($html);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix tooltip for disabled grid button


### Testing Instructions
In a backend list e.g. article list. (in your single user test system)
1. checkout an article as a first user = an edit article.
2. leave the editing by clicking the browsers back button.
3. The checked-out button shows a tool tip on hover - DO NOT CLICK IT!
4. Log out as first user - log in as another user. This user must not be allowed to check in records.
(user group setting in com.checkin -> not allowed)
5. Go to the list (articles)
6. Hover the checked-out button.

Quick-test:  change $canCheckin to false in line 262 tmpl/articles/deafult.php
<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>


![joomla-bug-is](https://user-images.githubusercontent.com/956537/66046976-2fcd9c00-e527-11e9-9b13-0a0a695184a6.jpg)

### Expected result

![joomla-bug-should](https://user-images.githubusercontent.com/956537/66047013-4247d580-e527-11e9-827a-90c0677135fe.jpg)


### Actual result

see above

### Documentation Changes Required
No
